### PR TITLE
Fixed the typo

### DIFF
--- a/src/components/Cart/CartItem/styles.js
+++ b/src/components/Cart/CartItem/styles.js
@@ -8,7 +8,7 @@ export default makeStyles(() => ({
     display: 'flex',
     justifyContent: 'space-between',
   },
-  cartActions: {
+  cardActions: {
     justifyContent: 'space-between',
   },
   buttons: {


### PR DESCRIPTION
We are referring to CardActions in CartItem but there is a typo in the styles and I fixed it. Now it is linked to the CardActions.